### PR TITLE
Testing, want to see the difference from master.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bundle.js
 coverage
 lib
 node_modules
+.vscode

--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -3,10 +3,10 @@ import { TimeGraphChart } from "timeline-chart/lib/layer/time-graph-chart";
 import { TimeGraphUnitController } from "timeline-chart/lib/time-graph-unit-controller";
 import { TimeGraphRowController } from "timeline-chart/lib/time-graph-row-controller";
 import { TimeGraphNavigator } from "timeline-chart/lib/layer/time-graph-navigator";
-import { TimeGraphContainer } from "timeline-chart/lib/time-graph-container";
 import { TimeGraphChartCursors } from "timeline-chart/lib/layer/time-graph-chart-cursors";
 import { TimeGraphChartSelectionRange } from "timeline-chart/lib/layer/time-graph-chart-selection-range";
 import { TimeGraphAxisCursors } from "timeline-chart/lib/layer/time-graph-axis-cursors";
+import { TimeGraphContainer } from "timeline-chart/lib/time-graph-container";
 // import { timeGraph } from "timeline-chart/lib/test-data";
 import { TimelineChart } from "timeline-chart/lib/time-graph-model";
 import { TimeGraphStateStyle } from "timeline-chart/lib/components/time-graph-state";
@@ -36,6 +36,7 @@ container.style.width = styleConfig.mainWidth + "px";
 const testDataProvider = new TestDataProvider(styleConfig.mainWidth);
 let timeGraph = testDataProvider.getData({});
 const unitController = new TimeGraphUnitController(timeGraph.totalLength);
+unitController.worldRenderFactor = 3;
 unitController.numberTranslator = (theNumber: bigint) => {
     let num = theNumber.toString();
     if (num.length > 6) {
@@ -54,11 +55,7 @@ const providers = {
         };
     },
     dataProvider: (range: TimelineChart.TimeGraphRange, resolution: number) => {
-        const length = range.end - range.start;
-        const overlap = length * BigInt(10);
-        const start = range.start - overlap > BigInt(0) ? range.start - overlap : BigInt(0);
-        const end = range.end + overlap < unitController.absoluteRange ? range.end + overlap : unitController.absoluteRange;
-        const newRange: TimelineChart.TimeGraphRange = { start, end };
+        const newRange: TimelineChart.TimeGraphRange = range;
         const newResolution: number = resolution * 0.1;
         timeGraph = testDataProvider.getData({ range: newRange, resolution: newResolution });
         return {
@@ -132,8 +129,9 @@ const timeGraphAxisContainer = new TimeGraphContainer({
 }, unitController, axisCanvas);
 axisHTMLContainer.appendChild(timeGraphAxisContainer.canvas);
 
+const timeAxisCursors = new TimeGraphAxisCursors('timeGraphAxisCursors', { color: styleConfig.cursorColor });
 const timeAxisLayer = new TimeGraphAxis('timeGraphAxis', { color: styleConfig.naviBackgroundColor, verticalAlign: 'bottom'});
-timeGraphAxisContainer.addLayers([timeAxisLayer]);
+timeGraphAxisContainer.addLayers([timeAxisLayer, timeAxisCursors]);
 
 const chartHTMLContainer = document.createElement('div');
 chartHTMLContainer.id = 'main_chart';
@@ -153,13 +151,12 @@ chartHTMLContainer.appendChild(timeGraphChartContainer.canvas);
 const timeGraphChartGridLayer = new TimeGraphChartGrid('timeGraphGrid', rowHeight);
 const timeGraphChart = new TimeGraphChart('timeGraphChart', providers, rowController);
 const timeGraphChartArrows = new TimeGraphChartArrows('timeGraphChartArrows', rowController);
-const timeAxisCursors = new TimeGraphAxisCursors('timeGraphAxisCursors', { color: styleConfig.cursorColor });
 const timeGraphSelectionRange = new TimeGraphChartSelectionRange('chart-selection-range', { color: styleConfig.cursorColor });
 const timeGraphChartCursors = new TimeGraphChartCursors('chart-cursors', timeGraphChart, rowController, { color: styleConfig.cursorColor });
 const timeGraphChartRangeEvents = new TimeGraphRangeEventsLayer('timeGraphChartRangeEvents', providers);
 
 timeGraphChartContainer.addLayers([timeGraphChartGridLayer, timeGraphChart,
-    timeGraphChartArrows, timeAxisCursors, timeGraphSelectionRange,
+    timeGraphChartArrows, timeGraphSelectionRange,
     timeGraphChartCursors, timeGraphChartRangeEvents]);
 
 timeGraphChart.registerMouseInteractions({

--- a/timeline-chart/src/bigint-utils.ts
+++ b/timeline-chart/src/bigint-utils.ts
@@ -30,4 +30,11 @@ export class BIMath {
         val = BIMath.round(val);
         return val >= 0 ? val : -val;
     };
+
+    static readonly multiply = (a: bigint | number, b: bigint | number): bigint => {
+        a = Number(a);
+        b = Number(b);
+        let c = a * b;
+        return BIMath.round(c);
+    }
 };

--- a/timeline-chart/src/components/time-graph-grid.ts
+++ b/timeline-chart/src/components/time-graph-grid.ts
@@ -27,6 +27,6 @@ export class TimeGraphGrid extends TimeGraphAxisScale {
     }
 
     render(): void {
-        this.renderVerticalLines(false, this._options.lineColor || 0xdddddd, () => ({ lineHeight: this.stateController.canvasDisplayHeight }));
+        this.renderVerticalLines(false, this._options.lineColor || 0xdddddd, () => ({ lineHeight: this.stateController.canvasDisplayHeight }), true);
     }
 }

--- a/timeline-chart/src/layer/time-graph-chart-arrows.ts
+++ b/timeline-chart/src/layer/time-graph-chart-arrows.ts
@@ -7,11 +7,11 @@ export class TimeGraphChartArrows extends TimeGraphChartLayer {
 
     protected arrows: Map<TimelineChart.TimeGraphArrow, TimeGraphArrowComponent>;
     protected rowIds: number[] = [];
-    private _updateHandler: { (): void; (viewRange: TimelineChart.TimeGraphRange): void; (viewRange: TimelineChart.TimeGraphRange): void; };
+    private _updateHandler: { (): void; (worldRange: TimelineChart.TimeGraphRange): void; (worldRange: TimelineChart.TimeGraphRange): void; };
 
     protected afterAddToContainer() {
         this._updateHandler = (): void => this.update();
-        this.unitController.onViewRangeChanged(this._updateHandler);
+        this.stateController.onWorldRender(this._updateHandler);
 
         this.rowController.onVerticalOffsetChangedHandler(verticalOffset => {
             this.layer.position.y = -verticalOffset;
@@ -24,13 +24,12 @@ export class TimeGraphChartArrows extends TimeGraphChartLayer {
         if (sourceIndex === -1 || destinationIndex === -1) {
             return undefined;
         }
-        const relativeStartPosition = arrow.range.start - this.unitController.viewRange.start;
         const start: TimeGraphElementPosition = {
-            x: this.getPixel(relativeStartPosition),
+            x: this.getWorldPixel(arrow.range.start),
             y: (sourceIndex * this.rowController.rowHeight) + (this.rowController.rowHeight / 2)
         }
         const end: TimeGraphElementPosition = {
-            x: this.getPixel(relativeStartPosition + arrow.range.end - arrow.range.start),
+            x: this.getWorldPixel(arrow.range.end),
             y: (destinationIndex * this.rowController.rowHeight) + (this.rowController.rowHeight / 2)
         }
         return { start, end };
@@ -83,7 +82,7 @@ export class TimeGraphChartArrows extends TimeGraphChartLayer {
 
     destroy() : void {
         if (this.unitController) {
-            this.unitController.removeViewRangeChangedHandler(this._updateHandler);
+            this.stateController.removeWorldRenderHandler(this._updateHandler);
         }
         super.destroy();
     }

--- a/timeline-chart/src/layer/time-graph-chart-cursors.ts
+++ b/timeline-chart/src/layer/time-graph-chart-cursors.ts
@@ -144,7 +144,7 @@ export class TimeGraphChartCursors extends TimeGraphChartLayer {
             }
         };
         this.onCanvasEvent('mousedown', this._mouseDownHandler);
-        this.unitController.onViewRangeChanged(this._updateHandler);
+        this.stateController.onWorldRender(this._updateHandler);
         this.unitController.onSelectionRangeChange(this._updateHandler);
         this.update();
     }
@@ -224,8 +224,8 @@ export class TimeGraphChartCursors extends TimeGraphChartLayer {
 
     update() {
         if (this.unitController.selectionRange) {
-            const firstCursorPosition = this.getPixel(this.unitController.selectionRange.start - this.unitController.viewRange.start);
-            const secondCursorPosition = this.getPixel(this.unitController.selectionRange.end - this.unitController.viewRange.start);
+            const firstCursorPosition = this.getWorldPixel(this.unitController.selectionRange.start);
+            const secondCursorPosition = this.getWorldPixel(this.unitController.selectionRange.end);
             const firstCursorOptions = {
                 color: this.color,
                 height: this.stateController.canvasDisplayHeight,
@@ -268,7 +268,7 @@ export class TimeGraphChartCursors extends TimeGraphChartLayer {
 
     destroy() : void {
         if (this.unitController) {
-            this.unitController.removeViewRangeChangedHandler(this._updateHandler);
+            this.stateController.removeWorldRenderHandler(this._updateHandler);
             this.unitController.removeSelectionRangeChangedHandler(this._updateHandler);
         }
         if (this._mouseDownHandler) {

--- a/timeline-chart/src/layer/time-graph-chart-grid.ts
+++ b/timeline-chart/src/layer/time-graph-chart-grid.ts
@@ -1,9 +1,9 @@
-import { TimeGraphLayer } from "./time-graph-layer";
+import { TimeGraphViewportLayer } from "./time-graph-viewport-layer";
 import { TimeGraphGrid } from "../components/time-graph-grid";
 import { TimelineChart } from "../time-graph-model";
 import { TimeGraphAxisLayerOptions } from "./time-graph-axis";
 
-export class TimeGraphChartGrid extends TimeGraphLayer {
+export class TimeGraphChartGrid extends TimeGraphViewportLayer {
 
     protected gridComponent: TimeGraphGrid;
     private _updateHandler: { (): void; (viewRange: TimelineChart.TimeGraphRange): void; (viewRange: TimelineChart.TimeGraphRange): void; (selectionRange: TimelineChart.TimeGraphRange): void; };;
@@ -21,7 +21,7 @@ export class TimeGraphChartGrid extends TimeGraphLayer {
         }, this.rowHeight, this.unitController, this.stateController);
         this.addChild(this.gridComponent);
         this._updateHandler = (): void => this.update();
-        this.unitController.onViewRangeChanged(this._updateHandler);
+        this.stateController.onWorldRender(this._updateHandler);
     }
 
     update(opts?: TimeGraphAxisLayerOptions) {
@@ -30,7 +30,7 @@ export class TimeGraphChartGrid extends TimeGraphLayer {
 
     destroy() : void {
         if (this.unitController) {
-            this.unitController.removeViewRangeChangedHandler(this._updateHandler);
+            this.stateController.removeWorldRenderHandler(this._updateHandler);
             this.unitController.removeSelectionRangeChangedHandler(this._updateHandler);
         }
         super.destroy();

--- a/timeline-chart/src/layer/time-graph-chart-layer.ts
+++ b/timeline-chart/src/layer/time-graph-chart-layer.ts
@@ -1,10 +1,10 @@
-import { TimeGraphLayer } from "./time-graph-layer";
 import { TimeGraphRowController } from "../time-graph-row-controller";
+import { TimeGraphViewportLayer } from "./time-graph-viewport-layer";
 
-export abstract class TimeGraphChartLayer extends TimeGraphLayer {
+export abstract class TimeGraphChartLayer extends TimeGraphViewportLayer {
 
-    constructor(id: string, protected rowController: TimeGraphRowController){
+    constructor(id: string, protected rowController: TimeGraphRowController) {
         super(id);
     }
-    
+
 }

--- a/timeline-chart/src/layer/time-graph-range-events-layer.ts
+++ b/timeline-chart/src/layer/time-graph-range-events-layer.ts
@@ -1,13 +1,13 @@
 import { TimeGraphRectangle } from "../components/time-graph-rectangle";
 import { TimelineChart } from "../time-graph-model";
 import { TimeGraphChartProviders } from "./time-graph-chart";
-import { TimeGraphLayer } from "./time-graph-layer";
+import { TimeGraphViewportLayer } from "./time-graph-viewport-layer";
 
-export class TimeGraphRangeEventsLayer extends TimeGraphLayer {
+export class TimeGraphRangeEventsLayer extends TimeGraphViewportLayer {
     protected rangeEvents: Map<TimelineChart.TimeGraphAnnotation, TimeGraphRectangle>;
     protected providers: TimeGraphChartProviders;
 
-    private _viewRangeUpdateHandler: { (): void; (viewRange: TimelineChart.TimeGraphRange): void; (viewRange: TimelineChart.TimeGraphRange): void; };
+    private _worldRangeUpdateHandler: { (): void; (worldRange: TimelineChart.TimeGraphRange): void; (worldRange: TimelineChart.TimeGraphRange): void; };
 
     constructor(id: string, providers: TimeGraphChartProviders) {
         super(id);
@@ -15,13 +15,13 @@ export class TimeGraphRangeEventsLayer extends TimeGraphLayer {
     }
 
     protected afterAddToContainer() {
-        this._viewRangeUpdateHandler = (): void => this.update();
-        this.unitController.onViewRangeChanged(this._viewRangeUpdateHandler);
+        this._worldRangeUpdateHandler = (): void => this.update();
+        this.stateController.onWorldRender(this._worldRangeUpdateHandler);
     }
 
     protected addRangeEvent(rangeEvent: TimelineChart.TimeGraphAnnotation) {
-        const start = this.getPixel(rangeEvent.range.start - this.unitController.viewRange.start);
-        const end = this.getPixel(rangeEvent.range.end - this.unitController.viewRange.start);
+        const start = this.getWorldPixel(rangeEvent.range.start);
+        const end = this.getWorldPixel(rangeEvent.range.end);
         const width = end - start;
         const elementStyle = this.providers.rowAnnotationStyleProvider ? this.providers.rowAnnotationStyleProvider(rangeEvent) : undefined;
         const rangeEventComponent = new TimeGraphRectangle({
@@ -61,8 +61,8 @@ export class TimeGraphRangeEventsLayer extends TimeGraphLayer {
 
     protected updateRangeEvent(rangeEvent: TimelineChart.TimeGraphAnnotation) {
         const rangeEventComponent = this.rangeEvents.get(rangeEvent);
-        const start = this.getPixel(rangeEvent.range.start - this.unitController.viewRange.start);
-        const end = this.getPixel(rangeEvent.range.end - this.unitController.viewRange.start);
+        const start = this.getWorldPixel(rangeEvent.range.start);
+        const end = this.getWorldPixel(rangeEvent.range.end);
         const width = end - start;
         if (rangeEventComponent) {
             rangeEventComponent.update({
@@ -78,7 +78,7 @@ export class TimeGraphRangeEventsLayer extends TimeGraphLayer {
 
     destroy(): void {
         if (this.unitController) {
-            this.unitController.removeViewRangeChangedHandler(this._viewRangeUpdateHandler);
+            this.stateController.removeWorldRenderHandler(this._worldRangeUpdateHandler);
         }
         super.destroy();
     }

--- a/timeline-chart/src/layer/time-graph-viewport-layer.ts
+++ b/timeline-chart/src/layer/time-graph-viewport-layer.ts
@@ -1,0 +1,40 @@
+import { TimeGraphLayer } from './time-graph-layer';
+import { BIMath } from '../bigint-utils';
+import { TimeGraphStateController } from '../time-graph-state-controller';
+import { TimeGraphUnitController } from '../time-graph-unit-controller';
+
+export abstract class TimeGraphViewportLayer extends TimeGraphLayer {
+
+    constructor(id: string) {
+        super(id);
+    }
+
+    /**
+     * Conveniently finds the pixel relative to the worldRangeStart.  Also clamps
+     * so components don't render past the world range.
+     * 
+     * @param {bigint} time the time to get the world pixel for
+     * @param {boolean} clamp if you want to clamp.  Default = false.
+     * @return pixel relative to world range
+     */
+    protected getWorldPixel = (time: bigint, clamp?: boolean): number => {
+        if (!this.unitController) {
+            throw 'No unit controller to calculate world pixel.';
+        }
+        const { start, end } = this.unitController.worldRange;
+
+        time = clamp ? BIMath.clamp(time, start, end) : time;
+        let diff = time - start;
+        return this.getPixel(diff);
+    };
+
+    initializeLayer(canvas: HTMLCanvasElement, stage: PIXI.Container, stateController: TimeGraphStateController, unitController: TimeGraphUnitController) {
+        super.initializeLayer(canvas, stage, stateController, unitController);
+        this.stateController.onPositionChanged(this.shiftStage);
+    }
+
+    protected shiftStage = () => {
+        this.layer.position.x = this.stateController.positionOffset.x;
+    }
+
+}


### PR DESCRIPTION
# Viewport Implementation for Timeline-Chart

## Purpose & Concept
Previously, the canvas/PIXI.Stage was being re-drawn before being re-rendered every time the view changed.  Re-draws are expensive and should be only used when necessary.  

This change implements the concept of having a "world".  The world can be drawn, and changes things like panning / zooming / resizing can be abstracted using the PIXI library. Modifying PIXI variables like position and scale can be used to modify what is shown instead of clearing the canvas of all PIXI objects and re-drawing them in the correct place.

Current implementation only properly handles horizontal panning, or moving left and right.  Other actions like zooming, window resize, and others, still require a manual re-draw.  These can be implemented in the future.

## Changes

### UnitController Changes

1. `worldRange` is added.
2. `WORLD_RENDER_FACTOR` added.  This determines how many `viewRanges` left and right of the new view to get data for.  It's currently set to 1, which is the same as before.
3. `updateWorldRangeFromViewRange`.  This does what it says, using `WORLD_RENDER_FACTOR` to calculate the new world size to set.  This is called in `TimeGraphChart#maybeFetchNewData` to determine what data to fetch.

### TimeGraphViewportContainer Class

TimeGraphViewportContainer is a child class of TimeGraphContainer that holds viewport logic.

1. `horizontalOffset` is used to modify `PIXI.stage.position.x` when the `unitController.viewRange` changes.  This is the main logic for handling horizontal panning.
2. `onWorldRender` event handlers.  These events trigger when after the world is redrawn in `TimeGraphChart#maybeFetchNewData` after the initial "coarse" render.
3. `addLayer` adds reference to the `ViewportContainer` to all layers, giving them access to public methods.

### TimeGraphViewportLayer Class

1. Has access to `ViewportContainer` and its public methods.
2. `getWorldPixel` is an abstraction of `TimeGraphLayer#getPixel`.  It gets the pixel relative to the world start, and has the option to clamp to world bounds.
3. Class inheritance is now `TimeGraphLayer` => `TimeGraphViewportLayer` => `TimeGraphChartLayer`.
4. Most or all handlers for `onViewRangeChanged` that lived in a `ChartLayer` were moved to the `onWorldRender` handler.  We are now only drawing  when re-drawing the world. 

### StateController OnZoomChange Implemented and Used

1. `onZoomChanged` handler was not functional or used before.
2. Used because there was an edge case when `worldRange = absoluteRange` and `viewRange < worldRange/absoluteRange`.  The entire trace was rendered to the world, and changing the view range by zooming out did not trigger any `onWorldRender` events that previously triggered  `onViewRangeChanged`.  `onZoomChanged` handler added to `TimeGraphChart` to force a world re-draw when the zoom changes.  (_This also adds a nice touch when zooming out, where the world becomes scaled-down and rendered relative to where it was before_).

## Performance Gains - Horizontal Panning

This is a "back of the napkin" check.  Trace used is "Many-Threads", with a size of ~8MB.
No other views were open, and Resource Status was resized for maximum vertical height.

CPU: AMD Ryzen 7 3700X
GPU:  EVGA GeForce RTX 3070
RAM: Corsair Vengeance 2x64 GB @ 3200 MHz

### Pre-Update
Re-draw + Render resulted in frame times from ~220-450ms, or 3 FPS.
Memory (blue line near the top) progressively spikes as we perform a re-draw.

![image](https://user-images.githubusercontent.com/98342456/189500482-8dc24b1a-a3f1-4f66-ade3-89f6e91337ba.png)

### Viewport
Frame times reduced to ~30-50ms.  Frames increased to 30 FPS.
Stable memory curve.

_**Note:** We are significantly more zoomed-in on this picture._

![image](https://user-images.githubusercontent.com/98342456/189500858-e78e54f2-187b-4bd7-a369-2a1fc4d364a8.png)

## Tech Debt
There is a shortcut solution for ensuring the container background and row lines are always visible.  They are updated every time the view range changes, and don't "beat to the same drum" as the other Viewport layers.  See `TimeGraphViewportContainer#updateBackground` and `TimeGraphChart#ensureRowLinesFitWidth`.






